### PR TITLE
Set aws cli default output to json overriding user profile default, r…

### DIFF
--- a/run_project.sh
+++ b/run_project.sh
@@ -57,6 +57,7 @@ if [ ! "$(docker ps -q -f name="${CONTAINER_NAME}")" ]; then
       -e ANSIBLE_SSH_RETRIES=10 \
       -e ANSIBLE_COLLECTIONS_PATH="/opt/cldr-runner/collections" \
       -e ANSIBLE_ROLES_PATH="/opt/cldr-runner/roles" \
+      -e AWS_DEFAULT_OUTPUT="json" \
       --mount "type=bind,source=${HOME}/.aws,target=/home/runner/.aws" \
       --mount "type=bind,source=${HOME}/.config,target=/home/runner/.config" \
       --mount "type=bind,source=${HOME}/.ssh,target=/home/runner/.ssh" \


### PR DESCRIPTION
…equired when aws cli commands are used within Ansible and json parsing is expected on output

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>