### PR TITLE
Fix CLDR_BUILD_VER setting and enhance build tag settings

### DIFF
--- a/.github/workflows/publish_image_github_packages.yml
+++ b/.github/workflows/publish_image_github_packages.yml
@@ -22,7 +22,7 @@ jobs:
           format: 'YYYY-MM-DD'
 
       - name: Set Release Version from Tag
-#        run: echo "RELEASE_VERSION=v0.6.3" >> $GITHUB_ENV
+#        run: echo "RELEASE_VERSION=v1.0.3.1" >> $GITHUB_ENV
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Push to GitHub Packages for Base Build
@@ -34,6 +34,7 @@ jobs:
           push: true
           build-args: |
             BUILD_DATE=${{ steps.date.outputs.time }}
+            BUILD_TAG=base-${{ env.RELEASE_VERSION }}
             CDPY=true
 
       - name: Get Time for Full Build
@@ -47,6 +48,7 @@ jobs:
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
+            BUILD_TAG=full-${{ env.RELEASE_VERSION }}
             AWS=true
             GCLOUD=true
             AZURE=true
@@ -68,6 +70,7 @@ jobs:
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
+            BUILD_TAG=aws-${{ env.RELEASE_VERSION }}
             AWS=true
             CDPY=true
             CACHE_TIME=${{ steps.awstime.outputs.time }}
@@ -87,6 +90,7 @@ jobs:
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
+            BUILD_TAG=gcp-${{ env.RELEASE_VERSION }}
             GCLOUD=true
             CDPY=true
             CACHE_TIME=${{ steps.gcptime.outputs.time }}
@@ -105,6 +109,7 @@ jobs:
           build-args: |
             BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
+            BUILD_TAG=azure-${{ env.RELEASE_VERSION }}
             AZURE=true
             CDPY=true
             CACHE_TIME=${{ steps.azuretime.outputs.time }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_TAG=stable-2.10-devel
 FROM ${BASE_IMAGE_URI}:${BASE_IMAGE_TAG} AS base
 
 ARG BUILD_DATE
-ARG IMAGE_FULL_NAME
+ARG BUILD_TAG
 ARG BASE_IMAGE_TAG
 
 # Copy Payload
@@ -27,7 +27,7 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && mv /runner/bashrc /home/runner/.bashrc
 
 ENV CLDR_BUILD_DATE=${BUILD_DATE}
-ENV CLDR_BUILD_VER=${BASE_IMAGE_TAG}
+ENV CLDR_BUILD_VER=${BUILD_TAG}
 
 # Metadata
 LABEL maintainer="Cloudera Labs <cloudera-labs@cloudera.com>" \
@@ -53,8 +53,18 @@ ARG GCLOUD
 ARG AZURE
 ARG CDPY
 
+# Update Build Information
+ARG BUILD_DATE
+ARG BUILD_TAG
+
 # Set random data to ensure this never caches
 ARG CACHE_TIME=placeholder
+
+ENV CLDR_BUILD_DATE=${BUILD_DATE}
+ENV CLDR_BUILD_VER=${BUILD_TAG}
+# Metadata
+LABEL org.label-schema.build-date="${CLDR_BUILD_DATE}" \
+      org.label-schema.version="${CLDR_BUILD_VER}"
 
 RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else dnf install -y kubectl ; fi \
     && if [[ -z "$AWS" ]] ; then echo AWS not requested ; else pip install --no-cache-dir -r /runner/deps/python_aws.txt ; fi \

--- a/common.sh
+++ b/common.sh
@@ -27,7 +27,7 @@ build_docker_image() {
     -t "${IMAGE_FULL_NAME}" \
     --build-arg BASE_IMAGE_URI=${BASE_IMAGE_URI} \
     --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
-    --build-arg IMAGE_FULL_NAME="${IMAGE_FULL_NAME}" \
+    --build-arg BUILD_TAG="${IMAGE_TAG}" \
     --build-arg BUILD_DATE="${BUILD_DATE}" \
     .
 }


### PR DESCRIPTION
Add explicit BUILD_TAG argument to Dockerfile build process to set CLDR_BUILD_VER more clearly
Remove unused IMAGE_FULL_NAME from Dockerfile build process
Add BUILD_DATE and BUILD_TAG metadata update to the options layer of the Dockerfile build process

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>