### PR TITLE
Add AWS IAM Authenticator for use with CDP K8s deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,11 @@ ARG CDPY
 ARG CACHE_TIME=placeholder
 
 RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else dnf install -y kubectl ; fi \
-    && if [[ -z "$AWS" ]] ; then echo AWS not requested ; else pip install --no-cache-dir -r /runner/deps/python_aws.txt ; fi \
+    && if [[ -z "$AWS" ]] ; then echo AWS not requested ; else \
+        pip install --no-cache-dir -r /runner/deps/python_aws.txt && \
+        curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator && \
+        chmod +x /usr/local/bin/aws-iam-authenticator \
+        ; fi \
     && if [[ -z "$GCLOUD" ]] ; then echo GCLOUD not requested ; else dnf install -y google-cloud-sdk && pip install --no-cache-dir -r /runner/deps/python_gcp.txt ; fi \
     && if [[ -z "$AZURE" ]] ; then echo AZURE not requested ; else dnf install -y azure-cli && pip install --no-cache-dir -r /runner/deps/python_azure.txt ; fi \
     && if [[ -z "$CDPY" ]] ; then echo CDPY not requested ; else pip install git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy --upgrade ; fi \


### PR DESCRIPTION
Add aws-iam-authenticator to the AWS options as it is required when working with AWS Kubernetes deployments

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>