### PR TITLE
Fix apache-atlas python client breaking pip dependency resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && dnf install -y python38-devel git curl which bash gcc terraform nano \
     && rm -rf /var/cache/dnf \
     && pip install -r /runner/deps/python_base.txt \
+    && pip install -r /runner/deps/python_secondary.txt \
     && ansible-galaxy role install -p /opt/cldr-runner/roles -r /runner/deps/ansible.yml \
     && ansible-galaxy collection install -p /opt/cldr-runner/collections -r /runner/deps/ansible.yml \
     && mkdir -p /home/runner/.ansible/log \

--- a/payload/deps/python_base.txt
+++ b/payload/deps/python_base.txt
@@ -19,7 +19,6 @@ openstacksdk
 openshift
 
 # CDP Runtime
-apache-atlas
 apache-ranger
 
 ## Append your additional Python requirements here

--- a/payload/deps/python_secondary.txt
+++ b/payload/deps/python_secondary.txt
@@ -1,0 +1,2 @@
+# Packages that are less well behaved and should be installed secondarily
+apache-atlas


### PR DESCRIPTION
The Python Package apache-atlas is not well-behaved and requires a much more recent version of requests than anything else, causing significant issues for pip to resolve dependencies. Therefore we move it to a seperate invocation of pip to avoid confusing the poor thing.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>