### PR TITLE
Minor improvements for 1.4.0 release

### DIFF
--- a/.github/workflows/publish_image_github_packages.yml
+++ b/.github/workflows/publish_image_github_packages.yml
@@ -21,16 +21,17 @@ jobs:
           timeZone: 0
           format: 'YYYY-MM-DD'
 
-      - name: Set Release Version from Tag
-#        run: echo "RELEASE_VERSION=v1.0.3.1" >> $GITHUB_ENV
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Prepare Environment Variables
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Push to GitHub Packages for Base Build
         uses: docker/build-push-action@v2.3.0
         with:
           tags: |
-            ghcr.io/cloudera-labs/cldr-runner:base-${{ env.RELEASE_VERSION }}
-            ghcr.io/cloudera-labs/cldr-runner:base-latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:base-${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:base-latest
           push: true
           build-args: |
             BUILD_DATE=${{ steps.date.outputs.time }}
@@ -46,7 +47,7 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
+            BASE_IMAGE_URI=ghcr.io/${{ env.IMAGE_REPOSITORY }}
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
             BUILD_TAG=full-${{ env.RELEASE_VERSION }}
             AWS=true
@@ -56,8 +57,8 @@ jobs:
             CDPY=true
             CACHE_TIME=${{ steps.fulltime.outputs.time }}
           tags: |
-            ghcr.io/cloudera-labs/cldr-runner:full-${{ env.RELEASE_VERSION }}
-            ghcr.io/cloudera-labs/cldr-runner:full-latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:full-${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:full-latest
 
       - name: Get Time for AWS Build
         id: awstime
@@ -68,15 +69,15 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
+            BASE_IMAGE_URI=ghcr.io/${{ env.IMAGE_REPOSITORY }}
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
             BUILD_TAG=aws-${{ env.RELEASE_VERSION }}
             AWS=true
             CDPY=true
             CACHE_TIME=${{ steps.awstime.outputs.time }}
           tags: |
-            ghcr.io/cloudera-labs/cldr-runner:aws-${{ env.RELEASE_VERSION }}
-            ghcr.io/cloudera-labs/cldr-runner:aws-latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:aws-${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:aws-latest
 
 
       - name: Get Time for GCP Build
@@ -88,15 +89,15 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
+            BASE_IMAGE_URI=ghcr.io/${{ env.IMAGE_REPOSITORY }}
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
             BUILD_TAG=gcp-${{ env.RELEASE_VERSION }}
             GCLOUD=true
             CDPY=true
             CACHE_TIME=${{ steps.gcptime.outputs.time }}
           tags: |
-            ghcr.io/cloudera-labs/cldr-runner:gcp-${{ env.RELEASE_VERSION }}
-            ghcr.io/cloudera-labs/cldr-runner:gcp-latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:gcp-${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:gcp-latest
 
       - name: Get Time for Azure Build
         id: azuretime
@@ -107,12 +108,12 @@ jobs:
         with:
           push: true
           build-args: |
-            BASE_IMAGE_URI=ghcr.io/cloudera-labs/cldr-runner
+            BASE_IMAGE_URI=ghcr.io/${{ env.IMAGE_REPOSITORY }}
             BASE_IMAGE_TAG=base-${{ env.RELEASE_VERSION }}
             BUILD_TAG=azure-${{ env.RELEASE_VERSION }}
             AZURE=true
             CDPY=true
             CACHE_TIME=${{ steps.azuretime.outputs.time }}
           tags: |
-            ghcr.io/cloudera-labs/cldr-runner:azure-${{ env.RELEASE_VERSION }}
-            ghcr.io/cloudera-labs/cldr-runner:azure-latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:azure-${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}:azure-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,18 @@ COPY payload /runner/
 # these built-ins are desired by setting the Ansible collections path variable
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && cp /runner/deps/*.repo /etc/yum.repos.d/ \
-    && dnf install -y python38-devel git curl which bash gcc terraform nano \
-    && rm -rf /var/cache/dnf \
+    && dnf clean expire-cache \
+    && dnf install -y python38-devel git curl which bash gcc terraform nano vim \
     && pip install -r /runner/deps/python_base.txt \
     && pip install -r /runner/deps/python_secondary.txt \
     && ansible-galaxy role install -p /opt/cldr-runner/roles -r /runner/deps/ansible.yml \
     && ansible-galaxy collection install -p /opt/cldr-runner/collections -r /runner/deps/ansible.yml \
     && mkdir -p /home/runner/.ansible/log \
-    && mv /runner/bashrc /home/runner/.bashrc
+    && mv /runner/bashrc /home/runner/.bashrc \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf \
+  	&& rm -rf /var/cache/yum \
+    && pip cache purge
 
 ENV CLDR_BUILD_DATE=${BUILD_DATE}
 ENV CLDR_BUILD_VER=${BUILD_TAG}
@@ -67,16 +71,31 @@ ENV CLDR_BUILD_VER=${BUILD_TAG}
 LABEL org.label-schema.build-date="${CLDR_BUILD_DATE}" \
       org.label-schema.version="${CLDR_BUILD_VER}"
 
-RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else dnf install -y kubectl ; fi \
+RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else \
+        dnf install -y kubectl \
+      ; fi \
     && if [[ -z "$AWS" ]] ; then echo AWS not requested ; else \
-        pip install --no-cache-dir -r /runner/deps/python_aws.txt && \
+        pip install -r /runner/deps/python_aws.txt && \
         curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator && \
         chmod +x /usr/local/bin/aws-iam-authenticator \
-        ; fi \
-    && if [[ -z "$GCLOUD" ]] ; then echo GCLOUD not requested ; else dnf install -y google-cloud-sdk && pip install --no-cache-dir -r /runner/deps/python_gcp.txt ; fi \
-    && if [[ -z "$AZURE" ]] ; then echo AZURE not requested ; else dnf install -y azure-cli && pip install --no-cache-dir -r /runner/deps/python_azure.txt ; fi \
-    && if [[ -z "$CDPY" ]] ; then echo CDPY not requested ; else pip install git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy --upgrade ; fi \
-    && ln -fs /usr/bin/python3 /usr/bin/python
+      ; fi \
+    && if [[ -z "$GCLOUD" ]] ; then echo GCLOUD not requested ; else \
+        dnf install -y google-cloud-sdk && \
+        pip install -r /runner/deps/python_gcp.txt \
+      ; fi \
+    && if [[ -z "$AZURE" ]] ; then echo AZURE not requested ; else \
+        dnf download azure-cli && \
+        rpm -ivh --nodeps azure-cli-*.rpm && \
+        rm -f azure-cli-*.rpm && \
+        pip install -r /runner/deps/python_azure.txt \
+      ; fi \
+    && if [[ -z "$CDPY" ]] ; then echo CDPY not requested ; else \
+        pip install git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy --upgrade \
+      ; fi \
+    && ln -fs /usr/bin/python3 /usr/bin/python \
+    && pip cache purge || True # This throws an error if there is nothing in the cache \
+    && dnf clean all \
+  	&& rm -rf /var/cache/yum
 
 ## Ensure gcloud and az are on global path
 ENV PATH "$PATH:/home/runner/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && ansible-galaxy collection install -p /opt/cldr-runner/collections -r /runner/deps/ansible.yml \
     && mkdir -p /home/runner/.ansible/log \
     && mv /runner/bashrc /home/runner/.bashrc \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf \
+    && echo "Purging Pip cache" &&  pip cache purge || echo "No Pip cache to purge" \
+    && echo "Cleaning dnf/yum cache" && dnf clean all \
   	&& rm -rf /var/cache/yum \
-    && pip cache purge
+    && rm -rf /var/cache/dnf
 
 ENV CLDR_BUILD_DATE=${BUILD_DATE}
 ENV CLDR_BUILD_VER=${BUILD_TAG}
@@ -92,10 +92,11 @@ RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else \
     && if [[ -z "$CDPY" ]] ; then echo CDPY not requested ; else \
         pip install git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy --upgrade \
       ; fi \
-    && ln -fs /usr/bin/python3 /usr/bin/python \
-    && pip cache purge || True # This throws an error if there is nothing in the cache \
-    && dnf clean all \
-  	&& rm -rf /var/cache/yum
+    && echo "Symlinking 'python3' to 'python'" && ln -fs /usr/bin/python3 /usr/bin/python \
+    && echo "Purging Pip cache" &&  pip cache purge || echo "No Pip cache to purge" \
+    && echo "Cleaning dnf/yum cache" && dnf clean all \
+  	&& rm -rf /var/cache/yum \
+    && rm -rf /var/cache/dnf
 
 ## Ensure gcloud and az are on global path
 ENV PATH "$PATH:/home/runner/.local/bin"

--- a/payload/deps/google-cloud-sdk.repo
+++ b/payload/deps/google-cloud-sdk.repo
@@ -3,6 +3,6 @@ name=Google Cloud SDK
 baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/payload/deps/kubernetes.repo
+++ b/payload/deps/kubernetes.repo
@@ -3,5 +3,5 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
Add vim as text editor option in Dockerfile.
Explicitly refresh dnf cache at start of run, and clean dnf and pip at end of layer build to avoid intermittent cache failures.
Remove pip option --no-cache-dir in favour of explicit cleanup of pip cache at end of layer build.
Add newlines to GCLOUD etc. options to improve readability.
Change Azure CLI install to use standalone rpm to avoid duplicate installations of python36 and python38 to reduce size and complexity.
Disable repo_gpgcheck on repos provided by Google as it intermittently fails due to expired gpg keys, and https is considered secure enough per their docs at https://cloud.google.com/compute/docs/troubleshooting/known-issues.
Change github action to use the calling repo (e.g. a fork) from environment variables instead of hardcoding the parent repo in cloudera-labs to reduce the risk of a mistaken push by a maintainer with write access during testing.
Add explanatory commentary to Dockerfile clean up actions for better log readability