### PR TITLE
Local development environments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ A Container image for running Ansible Playbooks and other common tools used with
 
 ## Introduction
 
-This image attempts to resolve common dependencies for a broad range of full-service deployments of Cloudera Software, covering depdencies on infrastructure creation, platform deployment, and other configuration considerations, in the convenient package of a single large container.
+This image attempts to resolve common dependencies for a broad range of full-service deployments of Cloudera Software, covering dependencies on infrastructure creation, platform deployment, and other configuration considerations, in the convenient package of a single large container.
 
 This is useful when your playbooks may need to use a combination of CLI, Collection, Role, Python, and other commands in order to achieve your outcomes - while it may be possible or preferential for these to be deployed separately we find a single integrated container moderately convenient for local development.
 
@@ -79,11 +79,13 @@ Please see included files under `./deps`.
 
 ## Local Development
 
-The `cldr-runner` project can also be used to bootstrap a local development environment on the native host environment (as opposed to a Docker image).  This option is more involved, but can avoid issues with Docker, such as mount latencies. 
+The `cldr-runner` project can also be used to bootstrap a local development environment on the native host environment (as opposed to a Docker image).  This option is more involved, but can avoid issues with Docker, such as mount latencies, and improve collection development. 
 
-The `local_environment.yml` playbook can set up a `cldr-runner`-like workspace for OSX and Ubuntu.  The playbook will clone the Cloudera collections and CDPy for local work, install the external Ansible dependencies, update the Python `venv`, and create a convenient setup script for future work.  
+The `local_environment.yml` playbook sets up a `cldr-runner`-like workspace for OSX and Ubuntu.  The playbook will clone the Cloudera collections and `cdpy` for local work, install the external Ansible dependencies, update the Python `venv`, and create a convenient setup script for future work.
 
-Development in this manner starts with sourcing the setup script, activating the virtual environment, and then switching to and running `cldr-runner`-based applications, such as `cloudera-deploy`, within their own projects. 
+NOTE: The cloned Cloudera collections and cdpy project use the `main` branches by default. Manipulating the branches, etc. is outside the scope of the `local_environment.yml` playbook.
+
+Development in this manner starts with sourcing the setup script, activating the virtual environment, and then switching to and running `cldr-runner`-based applications, such as `cloudera-deploy`, within their own projects while using the development environment's collections and tools. 
 
 You can change the execution environment by updating the Git-backed projects within the `ansible_collections` directory of the development environment or wholesale by changing the virtual environment and/or pointing to other development environments via the Ansible collection and role paths (see the setup scripts for details).
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,21 +1,25 @@
 # Cloudera Labs Ansible-Runner
 
-Readme last updated: 2021-03-17
+Readme last updated: 2022-02-09
 
-A Container image for running Ansible Playbooks and other common tools used with Cloudera Software on various Infrastructure Platforms. +
+A Container image for running Ansible Playbooks and other common tools used with Cloudera Software on various Infrastructure Platforms.
 
 ## Introduction
 
-This image attempts to resolve common dependencies for a broad range of full-service deployments of Cloudera Software, covering depdencies on infrastructure creation, platform deployment, and other configuration considerations, in the convenient package of a single large container.  +
-This is useful when your playbooks may need to use a combination of CLI, Collection, Role, Python, and other commands in order to achieve your outcomes - while it may be possible or preferential for these to be deployed separately we find a single integrated container moderately convenient for local development.  +
+This image attempts to resolve common dependencies for a broad range of full-service deployments of Cloudera Software, covering depdencies on infrastructure creation, platform deployment, and other configuration considerations, in the convenient package of a single large container.
+
+This is useful when your playbooks may need to use a combination of CLI, Collection, Role, Python, and other commands in order to achieve your outcomes - while it may be possible or preferential for these to be deployed separately we find a single integrated container moderately convenient for local development.
+
 It is based on the RedHat Ansible Runner, which provides a useful set of execution options including shell, direct container, and python import suitable for a variety of uses.
 
 ## Versions
-Upstream container is `quay.io/ansible/ansible-runner:stable-2.10-devel`  +
+
+Upstream container is `quay.io/ansible/ansible-runner:stable-2.10-devel`
+
 This provides Ansible as `2.10` and Python as `3.8`
 
 There are several switches within the Dockerfile to provide build output options for the user.
-Primarily these are to allow pruned images for working with each of the different usual Public cloud providers, or solely with CDP. The github actions builder runs on each release to produce example images you may use directly, or examine the Dockerfile to modify and build your own variant.  +
+Primarily these are to allow pruned images for working with each of the different usual Public cloud providers, or solely with CDP. The github actions builder runs on each release to produce example images you may use directly, or examine the Dockerfile to modify and build your own variant.
 
 Currently we provide the convenience builds: `base` `full` `aws` `azure` `gcp`  +
 They may be found on the https://github.com/orgs/cloudera-labs/packages/container/package/cldr-runner[Github Package Repository]
@@ -23,16 +27,18 @@ They may be found on the https://github.com/orgs/cloudera-labs/packages/containe
 ## Usage
 
 ### Dockerfile
-The Dockerfile depends on deps-ansible.yml and deps-python.yml, and may be used directly to produce an image or for other purposes.  +
+The Dockerfile depends on deps-ansible.yml and deps-python.yml, and may be used directly to produce an image or for other purposes. 
+
 For simplicity, you may wish to append your additional Ansible and Python deps to these files locally before building.
 
 ### common.sh
 This file sets the default names and variables used such as the image tag and container name, and hosts several shared convenience functions. It is not expected to be executed directly, but to serve as a central point to configure these values.
 
 ### build.sh
-Arguments: None +
-This is a convenience script to build the image locally and tag it as `cldr-runner:latest` by default. +
-It will stop and remove any currently running instances of the named container.  +
+
+_Arguments: None_ +
+This is a convenience script to build the image locally and tag it as `cldr-runner:latest` by default. It will stop and remove any currently running instances of the named container. 
+
 The image is approx ~2GB when fully constructed, which is why we have opted not to host it prebuilt at this time.
 
 ### run_project.sh
@@ -44,30 +50,75 @@ This is a convenience script to complete the following actions:
 * Use the first argument provided as the project dir within the container as `/runner/project`, consistent with Ansible-Runner practices
 * At this point it branches; either it will execute arbitrary commands and exit if they are passed in additionally to the project_dir, or it will enter a shell by default if no other arguments are passed
 
-*Examples:*  +
-`./run_project.sh /path/to/PycharmProjects`  +
-This would launch the container with PycharmProjects mounted in /runner/project within the container, and drop the user in a container shell with all tools available along with their various host machine user profile directories mounted. +
+#### Examples
+```bash
+./run_project.sh /path/to/PycharmProjects
+```
+This would launch the container with `PycharmProjects` mounted in `/runner/project` within the container, and drop the user in a container shell with all tools available along with their various host machine user profile directories mounted.
+
 This is an excellent environment in which to manage your various cloud credentials without resolving dependencies on your host machine, or interactively install further dependencies, or execute playbooks, etc.
 
-`./run_project.sh /path/to/myProject ansible-runner run -p site.yml /runner -vv`  +
-This would launch ansible-runner with the full path to myProject in /runner/project within the container. It would automatically execute ansible-runner with the playbook site.yml with /runner as the working directory and verbosity at 2v's, and then return to the host shell when complete. +
+```bash
+./run_project.sh /path/to/myProject ansible-runner run -p site.yml /runner -vv
+```
+This would launch `ansible-runner` with the full path to `myProject` in `/runner/project` within the container. It would automatically execute `ansible-runner` with the playbook `site.yml` with `/runner` as the working directory and verbosity at `2v` 's, and then return to the host shell when complete.
+
 This is an excellent shortcut to scripted execution where the user has already set up various profiles.
 
 ### Other Considerations
-ansible.cfg is configured to set long timeouts, currently based on the longest running CDP Public Canary job at 150mins
-ansible.cfg also adds the path /runner/project/collections as a root for Ansible Collections, so if you happen to have your collections under development in this path (strongly recommended) they will be automatically discovered by the container alongside collections in the default paths.
+
+`ansible.cfg` is configured to set long timeouts, currently based on the longest running CDP Public Canary job at 150mins.  `ansible.cfg` also adds the path `/runner/project/collections` as a root for Ansible Collections, so if you happen to have your collections under development in this path (strongly recommended) they will be automatically discovered by the container alongside collections in the default paths.
 
 ### Limitations
-We do not currently bring logs and build artifacts back to the host machine before stopping or removing the container, you should retrieve any artifacts you want to keep at the end of your session.
 
+We do not currently bring logs and build artifacts back to the host machine before stopping or removing the container, you should retrieve any artifacts you want to keep at the end of your session.
 
 ## Included Components
 
-Please see included files under ./deps
+Please see included files under `./deps`.
+
+## Local Development
+
+The `cldr-runner` project can also be used to bootstrap a local development environment on the native host environment (as opposed to a Docker image).  This option is more involved, but can avoid issues with Docker, such as mount latencies. 
+
+The `local_environment.yml` playbook can set up a `cldr-runner`-like workspace for OSX and Ubuntu.  The playbook will clone the Cloudera collections and CDPy for local work, install the external Ansible dependencies, update the Python `venv`, and create a convenient setup script for future work.  
+
+Development in this manner starts with sourcing the setup script, activating the virtual environment, and then switching to and running `cldr-runner`-based applications, such as `cloudera-deploy`, within their own projects. 
+
+You can change the execution environment by updating the Git-backed projects within the `ansible_collections` directory of the development environment or wholesale by changing the virtual environment and/or pointing to other development environments via the Ansible collection and role paths (see the setup scripts for details).
+
+*Follow these steps to set up a local environment:*
+
+Create a new virtual environment (using your favorite `venv` app):
+```bash
+$ mkvirtualenv <your development directory>
+```
+
+Set up the bootstrap requirements:
+```bash
+$ export ANSIBLE_COLLECTIONS_PATH=<your target development directory>
+$ pip install ansible-base==2.10.16
+$ ansible-galaxy collection install community.general
+```
+
+Make sure you are able to connect to public GitHub via SSH and then construct the development environment:
+```bash
+$ ansible-playbook local_development.yml
+```
+
+NOTE: For Ubuntu deployments, you will need to add the `--ask-become-pass` flag.
+
+Source the `setup-ansible-env.sh` file to use this development environment.
+```bash
+$ source <your development directory>/setup-ansible-env.sh
+```
 
 ## Developers
-Note that sequencing and dependency changes should be annotated in comments as to _why_ that change is considered necessary.  +
-Currently the file trades off duplication and therefore size-on-disk in order to maintain easy compatibility between components with conflicting versions. Examples of this include Azure CLI and Azure Collection requiring different Azure Python library versions, or CDP CLI tending to trail Azure on the shared but version-pinned Colorama dependency.  +
+
+Note that sequencing and dependency changes should be annotated in comments as to _why_ that change is considered necessary.
+
+Currently the file trades off duplication and therefore size-on-disk in order to maintain easy compatibility between components with conflicting versions. Examples of this include Azure CLI and Azure Collection requiring different Azure Python library versions, or CDP CLI tending to trail Azure on the shared but version-pinned Colorama dependency. 
+
 Where conflict arises, the Ansible Collection dependencies are installed to the system python environment, and the CLIs are installed to virtualenvs using pipx.
 
 ## Contributing

--- a/local_development.yml
+++ b/local_development.yml
@@ -72,7 +72,7 @@
             repo: "{{ item.repo }}"
             filename: "{{ item.name }}"
             state: "present"
-          with_items:
+          loop:
             - { name: "terraform", repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main" }
             - { name: "kubectl", repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main" }
             - { name: "google-cloud-sdk", repo: "deb https://packages.cloud.google.com/apt cloud-sdk main" }
@@ -102,7 +102,7 @@
             url: "{{ item.download_url }}"
             dest: "/usr/local/bin/{{ item.exe }}"
             mode: 0555
-          with_items: 
+          loop: 
             - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
       tags: system
 

--- a/local_development.yml
+++ b/local_development.yml
@@ -13,16 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# First, create a new virtual environment
-# e.g. mkvirtualenv my_devel_env
+### First, create a new virtual environment (using your favorite venv app)
 #
-# Then set up the bootstap:
+# mkvirtualenv <your development directory>
+#
+### Set up the bootstrap requirements:
+#
 # export ANSIBLE_COLLECTIONS_PATH=<your development directory>
-# pip install ansible-core
+# pip install ansible-base==2.10.16
 # ansible-galaxy collection install community.general
-# 
-# Then construct the development environment:
+#
+### Make sure you are using SSH to public Github and then construct the development environment:
+#
 # ansible-playbook local_development.yml
+#
+# NOTE: For Ubuntu deployments, you will need to add the `--ask-become-pass` flag.
+#
+### Then source the `setup.sh` file for fully configure for this environment.
+#
+# source <your development directory>/setup.sh
 
 - name: Set up a local venv-based development environment
   hosts: localhost
@@ -55,7 +64,6 @@
     - name: Add pacakge keys and repositories for Ubuntu
       when: ansible_distribution == "Ubuntu"
       block:
-
         - name: Add package keys
           become: yes
           ansible.builtin.apt_key:
@@ -73,14 +81,28 @@
             filename: "{{ item.name }}"
             state: "present"
           loop:
-            - { name: "terraform", repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main" }
-            - { name: "kubectl", repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main" }
-            - { name: "google-cloud-sdk", repo: "deb https://packages.cloud.google.com/apt cloud-sdk main" }
-            - { name: "azure-cli", repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main" }
+            - name: "terraform"
+              repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+            - name: "kubectl"
+              repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main"
+            - name: "google-cloud-sdk"
+              repo: "deb https://packages.cloud.google.com/apt cloud-sdk main"
+            - name: "azure-cli"
+              repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main"
       tags: system
 
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
+      ansible.builtin.package:
+        name:
+          - pip
+          - git
+          - terraform
+          - kubectl
+          - aws-iam-authenticator
+          - google-cloud-sdk
+          #- azure-cli
+        state: present
       tags: system
       block:
         - name: Install commands via package manager
@@ -104,7 +126,8 @@
               register: command_availability
               ignore_errors: true
               loop:
-                - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
+                - exe: "aws-iam-authenticator"
+                  download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator"
 
             # If command found not to be available download and install
             - name: Download and install any required commands (may take some time)
@@ -124,7 +147,7 @@
           - terraform
           - kubectl
           - aws-iam-authenticator
-          - azure-cli
+          #- azure-cli
         state: present
       tags: system
 
@@ -137,6 +160,7 @@
       failed_when: not (__osx_gcloud.msg is search("already installed") or __osx_gcloud.msg is search("Update done"))
       tags: system
 
+    # TODO Add azure-mgmt-netapp to python_azure.txt
     - name: Set up the Python dependencies
       ansible.builtin.pip:
         requirements: "{{ item }}"
@@ -145,6 +169,7 @@
       loop:
         - python_base.txt
         - python_secondary.txt
+        - python_aws.txt
         - python_gcp.txt
         - python_azure.txt
       tags: python
@@ -188,16 +213,25 @@
       loop: "{{ collection_dependencies | dict2items | rejectattr('key', 'match', 'git+') | list }}"
       tags: collections
 
-    # TODO Install Netapp.Azure from Git
-    - name: Warn user about missing Netapp Azure collection
-      ansible.builtin.debug:
-        msg: |
-          ===== WARNING WARNING WARNING WARNING WARNING WARNING WARNING =====
+    - name: Fix the azure-cli-core mismatch for ADAL-to-MSAL fiasco
+      ansible.builtin.pip:
+        name: azure-cli-core==2.30.0
+        state: present
+      tags: collections
 
-          You must install the Netapp Azure collection by hand at this time.
-          
-          ===== WARNING WARNING WARNING WARNING WARNING WARNING WARNING =====
-      tags: collection
+    # TODO Install Netapp.Azure from Git -- or --
+    # add netapp.azure to the collection deps
+    - name: Netapp Azure Python deps
+      ansible.builtin.pip:
+        name: azure-mgmt-netapp
+        state: present
+      tags: python
+
+    - name: Netapp Azure Ansible collection
+      community.general.ansible_galaxy_install:
+        type: collection
+        name: netapp.azure
+      tags: collections
 
     - name: Parse the Cloudera automation standalone role dependencies
       ansible.builtin.set_fact:

--- a/local_development.yml
+++ b/local_development.yml
@@ -93,17 +93,6 @@
 
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
-      ansible.builtin.package:
-        name:
-          - pip
-          - git
-          - terraform
-          - kubectl
-          - aws-iam-authenticator
-          - google-cloud-sdk
-          #- azure-cli
-        state: present
-      tags: system
       block:
         - name: Install commands via package manager
           become: yes

--- a/local_development.yml
+++ b/local_development.yml
@@ -81,6 +81,7 @@
 
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
+      tags: system
       block:
         - name: Install commands via package manager
           become: yes
@@ -94,17 +95,26 @@
               - azure-cli
             state: present
         
-        # TODO: Determine if aws-iam-authenticator already exists in path and skip below if it does
+        - name: Install commands via download 
+          block:
+            # Determine if the executable already exists in path
+            - name: Check if commands are already available
+              ansible.builtin.command:
+                cmd: "which {{ item.exe }}"
+              register: command_availability
+              ignore_errors: true
+              loop:
+                - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
 
-        - name: Install commands via download (may take some time)
-          become: yes
-          ansible.builtin.get_url:
-            url: "{{ item.download_url }}"
-            dest: "/usr/local/bin/{{ item.exe }}"
-            mode: 0555
-          loop: 
-            - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
-      tags: system
+            # If command found not to be available download and install
+            - name: Download and install any required commands (may take some time)
+              become: yes
+              ansible.builtin.get_url:
+                url: "{{ item.item.download_url }}"
+                dest: "/usr/local/bin/{{ item.item.exe }}"
+                mode: 0555
+              when: item.rc != 0
+              loop: "{{ command_availability.results }}"
 
     - name: Ensure availability of system commands (MacOSX)
       when: ansible_distribution == "MacOSX"

--- a/local_development.yml
+++ b/local_development.yml
@@ -13,37 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-### First, create a new virtual environment (using your favorite venv app)
-#
-# mkvirtualenv <your development directory>
-#
-### Set up the bootstrap requirements:
-#
-# export ANSIBLE_COLLECTIONS_PATH=<your development directory>
-# pip install ansible-base==2.10.16
-# ansible-galaxy collection install community.general
-#
-### Make sure you are using SSH to public Github and then construct the development environment:
-#
-# ansible-playbook local_development.yml
-#
-# NOTE: For Ubuntu deployments, you will need to add the `--ask-become-pass` flag.
-#
-### Then source the `setup.sh` file for fully configure for this environment.
-#
-# source <your development directory>/setup.sh
-
 - name: Set up a local venv-based development environment
   hosts: localhost
   connection: local
   gather_facts: yes
   tasks:
-    - name: Confirm development workspace location
+    - name: Confirm prerequisite environment variables are set
       ansible.builtin.assert:
-        that: lookup('env', item) | length > 0
-        fail_msg: "Define your development workspace location by setting {{ item }}."
+        that: lookup('env', item.variable) | length > 0
+        fail_msg: "{{ item.error_msg }}"
       loop:
-        - ANSIBLE_COLLECTIONS_PATH
+        - variable: ANSIBLE_COLLECTIONS_PATH
+          error_msg: "Define your development workspace target location by setting ANSIBLE_COLLECTIONS_PATH."
+        - variable: VIRTUAL_ENV
+          error_msg: "Activate your development virtual environment."
       tags: precheck
 
     - name: Ensure credential and profile paths for SSH, CDP, and cloud providers are available
@@ -61,7 +44,7 @@
         HOME: "{{ lookup('env','HOME') }}"
       tags: credentials
 
-    - name: Add pacakge keys and repositories for Ubuntu
+    - name: Add package keys and repositories for Ubuntu
       when: ansible_distribution == "Ubuntu"
       block:
         - name: Add package keys
@@ -220,6 +203,7 @@
       community.general.ansible_galaxy_install:
         type: collection
         name: netapp.azure
+        force: true
       tags: collections
 
     - name: Parse the Cloudera automation standalone role dependencies
@@ -264,22 +248,27 @@
       ansible.builtin.copy:
         content: |
           #!/bin/sh
+
+          # Source this file to set up the development environment
+
           export ANSIBLE_COLLECTIONS_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
           export ANSIBLE_ROLES_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/roles
-        dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh"
+        dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup-ansible-env.sh"
         mode: 0755
       tags: coda
 
     - name: Print instructions
-      ansible.builtin.debug:
+      vars:
         msg: |
           To use this local development environment for Cloudera automation,
           set the following environment variables:
 
             export ANSIBLE_COLLECTIONS_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
-            export ANSIBLE_ROLES_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
+            export ANSIBLE_ROLES_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/roles
 
-          Or use the script, {{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh
+          Or source the script, {{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup-ansible-env.sh
 
-            source {{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh
+            source {{ lookup('env', 'CLDR_DEVELOPMENT_PATH') }}/setup-cldr-devel.sh
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
       tags: coda

--- a/local_development.yml
+++ b/local_development.yml
@@ -1,0 +1,212 @@
+---
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First, create a new virtual environment
+# e.g. mkvirtualenv my_devel_env
+#
+# Then set up the bootstap:
+# export ANSIBLE_COLLECTIONS_PATH=<your development directory>
+# pip install ansible-core
+# ansible-galaxy collection install community.general
+# 
+# Then construct the development environment:
+# ansible-playbook local_development.yml
+
+- name: Set up a local venv-based development environment
+  hosts: localhost
+  connection: local
+  gather_facts: yes
+  tasks:
+    - name: Confirm development workspace location
+      ansible.builtin.assert:
+        that: lookup('env', item) | length > 0
+        fail_msg: "Define your development workspace location by setting {{ item }}."
+      loop:
+        - ANSIBLE_COLLECTIONS_PATH
+      tags: precheck
+
+    - name: Ensure credential and profile paths for SSH, CDP, and cloud providers are available
+      ansible.builtin.file:
+        path: "{{ HOME }}/{{ item }}"
+        state: directory
+        force: no
+      loop:
+        - ".ssh"
+        - ".cdp"
+        - ".aws"
+        - ".azure"
+        - ".kube"
+      vars:
+        HOME: "{{ lookup('env','HOME') }}"
+      tags: credentials
+
+    - name: Ensure availability of system commands
+      when: ansible_distribution != "MacOSX"
+      ansible.builtin.package:
+        name:
+          - pip
+          - git
+          - terraform
+          - kubectl
+          - aws-iam-authenticator
+          - google-cloud-sdk
+          - azure-cli
+        state: present
+      tags: system
+
+    - name: Ensure availability of system commands (MacOSX)
+      when: ansible_distribution == "MacOSX"
+      community.general.homebrew:
+        name:
+          - git
+          - terraform
+          - kubectl
+          - aws-iam-authenticator
+          - azure-cli
+        state: present
+      tags: system
+
+    - name: Ensure availability of Gcloud system commands (MacOSX)
+      when: ansible_distribution == "MacOSX"
+      community.general.homebrew:
+        name: google-cloud-sdk
+        state: present
+      register: __osx_gcloud
+      failed_when: not (__osx_gcloud.msg is search("already installed") or __osx_gcloud.msg is search("Update done"))
+      tags: system
+
+    - name: Set up the Python dependencies
+      ansible.builtin.pip:
+        requirements: "{{ item }}"
+        chdir: "./payload/deps"
+        state: present
+      loop:
+        - python_base.txt
+        - python_secondary.txt
+        - python_gcp.txt
+        - python_azure.txt
+      tags: python
+
+    - name: Install the CDP CLI itself
+      ansible.builtin.pip:
+        name: cdpcli-beta
+        state: present
+      tags: python
+
+    - name: Clone the Cloudera automation collections
+      ansible.builtin.git:
+        repo: "{{ item.repo }}"
+        dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/ansible_collections/cloudera/{{ item.collection}}"
+      loop:
+        - repo: git@github.com:cloudera-labs/cloudera.cloud.git
+          collection: cloud
+        - repo: git@github.com:cloudera-labs/cloudera.cluster.git
+          collection: cluster
+        - repo: git@github.com:cloudera-labs/cloudera.exe.git
+          collection: exe
+      register: __cldr_collections
+      tags:
+        - collections
+        - roles
+
+    - name: Parse the Cloudera automation collection dependencies
+      ansible.builtin.set_fact:
+        collection_dependencies: "{{ collection_dependencies | default({}) | combine(galaxy.dependencies) }}"
+      vars:
+        file: "{{ item }}/galaxy.yml"
+        galaxy: "{{ lookup('file', file) | from_yaml }}"
+      loop: "{{ __cldr_collections.results | map(attribute='invocation') | map(attribute='module_args') | map(attribute='dest') | list }}"
+      tags: collections
+
+    - name: Install the Cloudera automation collection dependencies
+      community.general.ansible_galaxy_install:
+        type: collection
+        name: "{{ item.key }}:{{ item.value }}"
+        force: true
+      loop: "{{ collection_dependencies | dict2items | rejectattr('key', 'match', 'git+') | list }}"
+      tags: collections
+
+    # TODO Install Netapp.Azure from Git
+    - name: Warn user about missing Netapp Azure collection
+      ansible.builtin.debug:
+        msg: |
+          ===== WARNING WARNING WARNING WARNING WARNING WARNING WARNING =====
+
+          You must install the Netapp Azure collection by hand at this time.
+          
+          ===== WARNING WARNING WARNING WARNING WARNING WARNING WARNING =====
+      tags: collection
+
+    - name: Parse the Cloudera automation standalone role dependencies
+      ansible.builtin.set_fact:
+        role_dependencies: "{{ role_dependencies | default([]) | union([file]) }}"
+      vars:
+        file: "{{ item }}/requirements.yml"
+      loop: "{{ __cldr_collections.results | map(attribute='invocation') | map(attribute='module_args') | map(attribute='dest') | list }}"
+      tags: roles
+
+    - name: Install the Cloudera automation role dependencies
+      community.general.ansible_galaxy_install:
+        type: role
+        requirements_file: "{{ item }}"
+        force: true
+      when: item is exists
+      environment:
+        ANSIBLE_ROLES_PATH: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/roles"
+      loop: "{{ role_dependencies }}"
+      tags: roles
+
+    - name: Uninstall cdpy Python library
+      ansible.builtin.pip:
+        name: cdpy
+        state: absent
+      tags: cdpy
+
+    - name: Clone the cdpy Python library project
+      ansible.builtin.git:
+        repo: "git@github.com:cloudera-labs/cdpy.git"
+        dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/cdpy"
+      tags: cdpy
+
+    - name: Install the local cdpy library
+      ansible.builtin.pip:
+        chdir: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/cdpy"
+        editable: yes
+        name: .
+      tags: cdpy
+
+    - name: Create the environment setup script
+      ansible.builtin.copy:
+        content: |
+          #!/bin/sh
+          export ANSIBLE_COLLECTIONS_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
+          export ANSIBLE_ROLES_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/roles
+        dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh"
+        mode: 0755
+      tags: coda
+
+    - name: Print instructions
+      ansible.builtin.debug:
+        msg: |
+          To use this local development environment for Cloudera automation,
+          set the following environment variables:
+
+            export ANSIBLE_COLLECTIONS_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
+            export ANSIBLE_ROLES_PATH={{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}
+
+          Or use the script, {{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh
+
+            source {{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/setup.sh
+      tags: coda

--- a/local_development.yml
+++ b/local_development.yml
@@ -52,18 +52,58 @@
         HOME: "{{ lookup('env','HOME') }}"
       tags: credentials
 
+    - name: Add pacakge keys and repositories for Ubuntu
+      when: ansible_distribution == "Ubuntu"
+      block:
+
+        - name: Add package keys
+          become: yes
+          ansible.builtin.apt_key:
+            url: "{{ item }}"
+            state: present
+          loop:
+            - https://apt.releases.hashicorp.com/gpg # for terraform
+            - https://packages.cloud.google.com/apt/doc/apt-key.gpg # for kubectl & google-cloud-sdk
+            - https://packages.microsoft.com/keys/microsoft.asc # for azure-cli
+        
+        - name: Add package repositories
+          become: yes
+          ansible.builtin.apt_repository:
+            repo: "{{ item.repo }}"
+            filename: "{{ item.name }}"
+            state: "present"
+          with_items:
+            - { name: "terraform", repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main" }
+            - { name: "kubectl", repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main" }
+            - { name: "google-cloud-sdk", repo: "deb https://packages.cloud.google.com/apt cloud-sdk main" }
+            - { name: "azure-cli", repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main" }
+      tags: system
+
     - name: Ensure availability of system commands
       when: ansible_distribution != "MacOSX"
-      ansible.builtin.package:
-        name:
-          - pip
-          - git
-          - terraform
-          - kubectl
-          - aws-iam-authenticator
-          - google-cloud-sdk
-          - azure-cli
-        state: present
+      block:
+        - name: Install commands via package manager
+          become: yes
+          ansible.builtin.package:
+            name:
+              - pip
+              - git
+              - terraform
+              - kubectl
+              - google-cloud-sdk
+              - azure-cli
+            state: present
+        
+        # TODO: Determine if aws-iam-authenticator already exists in path and skip below if it does
+
+        - name: Install commands via download (may take some time)
+          become: yes
+          ansible.builtin.get_url:
+            url: "{{ item.download_url }}"
+            dest: "/usr/local/bin/{{ item.exe }}"
+            mode: 0555
+          with_items: 
+            - { exe: "aws-iam-authenticator", download_url: "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" }
       tags: system
 
     - name: Ensure availability of system commands (MacOSX)


### PR DESCRIPTION
Instructions and playbook for setting up a local, i.e. non-Docker, execution and development environment for `cldr-runner`. The playbook will clone the Cloudera collections, install the other prereqs, update the Python environment, etc.  The purpose is to make local development environments easier to maintain and switch when working on upstream applications (like `cloudera-deploy`) and definitions.  In particular, this setup works very well with Visual Studio Code's workspaces.