### PR TITLE
Add ansible_python_interpreter to default localhost inventory

### DIFF
--- a/payload/inventory/hosts
+++ b/payload/inventory/hosts
@@ -1,1 +1,1 @@
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
Signed-off-by: Webster Mudge <wmudge@cloudera.com>