### PR TITLE
Updated base image to 2.12-latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_URI=quay.io/ansible/ansible-runner
-ARG BASE_IMAGE_TAG=stable-2.10-latest
+ARG BASE_IMAGE_TAG=stable-2.12-latest
 
 FROM ${BASE_IMAGE_URI}:${BASE_IMAGE_TAG} AS base
 
@@ -76,7 +76,7 @@ RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else \
       ; fi \
     && if [[ -z "$AWS" ]] ; then echo AWS not requested ; else \
         pip install -r /runner/deps/python_aws.txt && \
-        curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator && \
+        curl -o /usr/local/bin/aws-iam-authenticator https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
         chmod +x /usr/local/bin/aws-iam-authenticator && \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && \
         unzip /tmp/awscliv2.zip -d /tmp && \
@@ -92,7 +92,7 @@ RUN if [[ -z "$KUBECTL" ]] ; then echo KUBECTL not requested ; else \
         rpm -ivh --nodeps azure-cli-*.rpm && \
         rm -f azure-cli-*.rpm && \
         pip install -r /runner/deps/python_azure.txt && \
-        pip install azure-cli-core==2.30.0 --upgrade \
+        pip install azure-cli-core==2.37.0 --upgrade \
       ; fi \
     && if [[ -z "$CDPY" ]] ; then echo CDPY not requested ; else \
         pip install git+https://github.com/cloudera-labs/cdpy@main#egg=cdpy --upgrade \

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # Cloudera Labs Ansible-Runner
 
-Readme last updated: 2022-02-09
+Readme last updated: 2022-07-04
 
 A Container image for running Ansible Playbooks and other common tools used with Cloudera Software on various Infrastructure Platforms.
 
@@ -14,9 +14,9 @@ It is based on the RedHat Ansible Runner, which provides a useful set of executi
 
 ## Versions
 
-Upstream container is `quay.io/ansible/ansible-runner:stable-2.10-devel`
+Upstream container is `quay.io/ansible/ansible-runner:stable-2.12-latest`
 
-This provides Ansible as `2.10` and Python as `3.8`
+This provides Ansible as `2.12` and Python as `3.8`
 
 There are several switches within the Dockerfile to provide build output options for the user.
 Primarily these are to allow pruned images for working with each of the different usual Public cloud providers, or solely with CDP. The github actions builder runs on each release to produce example images you may use directly, or examine the Dockerfile to modify and build your own variant.

--- a/common.sh
+++ b/common.sh
@@ -2,7 +2,7 @@
 
 # Update readme if you change versions!
 BASE_IMAGE_URI="quay.io/ansible/ansible-runner"
-BASE_IMAGE_TAG="stable-2.10-devel"
+BASE_IMAGE_TAG="stable-2.12-latest"
 IMAGE_NAME=cldr-runner
 IMAGE_TAG=base-latest
 IMAGE_FULL_NAME=${IMAGE_NAME}:${IMAGE_TAG}

--- a/payload/deps/python_aws.txt
+++ b/payload/deps/python_aws.txt
@@ -1,7 +1,7 @@
 # AWS collection requirements
 
 # Pinned to community.aws==3.0.1 (set in cloudera.exe)
--r https://raw.githubusercontent.com/ansible-collections/community.aws/3.0.1/requirements.txt
+-r https://raw.githubusercontent.com/ansible-collections/community.aws/4.0.0/requirements.txt
 
 # Pinned to amazon.aws==3.0.0 (set in cloudera.exe)
--r https://raw.githubusercontent.com/ansible-collections/amazon.aws/3.0.0/requirements.txt
+-r https://raw.githubusercontent.com/ansible-collections/amazon.aws/4.0.0/requirements.txt

--- a/payload/deps/python_azure.txt
+++ b/payload/deps/python_azure.txt
@@ -1,6 +1,6 @@
 # Azure Collection requirements, as distinct from Azure CLI
-# Pinned to az.collection==1.11.0 (set in cloudera.exe)
--r https://raw.githubusercontent.com/ansible-collections/azure/v1.11.0/requirements-azure.txt
+# Pinned to az.collection==1.13.0 (set in cloudera.exe)
+-r https://raw.githubusercontent.com/ansible-collections/azure/v1.13.0/requirements-azure.txt
 
 # NetApp Collection requirements
 # Pinned to netapp.azure==21.10.0 (set in cloudera.exe)

--- a/payload/deps/python_base.txt
+++ b/payload/deps/python_base.txt
@@ -6,6 +6,9 @@ requests[security]>=2.27.1
 urllib3>1.24.2
 cryptography>=2.3.1
 
+# https://github.com/paramiko/paramiko/issues/2038
+paramiko>=2.11.0
+
 # Ansible
 jmespath
 netaddr
@@ -20,7 +23,7 @@ openshift
 
 # CDP Runtime
 apache-ranger==0.0.5
-nipyapi==0.18.0
+nipyapi==0.19.0
 kafka-python==2.0.2
 
 ## Append your additional Python requirements here

--- a/payload/deps/python_gcp.txt
+++ b/payload/deps/python_gcp.txt
@@ -1,2 +1,2 @@
 # Google Collection requirements
-google-auth
+google-auth>=2.9.0

--- a/payload/deps/python_secondary.txt
+++ b/payload/deps/python_secondary.txt
@@ -1,2 +1,2 @@
 # Packages that are less well behaved and should be installed secondarily
-apache-atlas
+apache-atlas==0.0.11


### PR DESCRIPTION
Updated Ansible Collections deps to 4.0.0+
Updated Azure deps to latest
Set minimum paramiko version to 2.11 to bypass blowfish deprecation issue in cryptography
Pinned google-auth to at least current version
Pinned apache-atlas to current version
Updated aws-iam-authentication to latest version
Updated azure-cli-core to 2.37 in preparation for testing new authentication mechanisms
Updated README.adoc

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>