### PR TITLE
Improve local_development.yml file to allow users choose between HTTPS/GIT clone methods.

### DIFF
--- a/local_development.yml
+++ b/local_development.yml
@@ -18,6 +18,14 @@
   connection: local
   gather_facts: yes
   tasks:
+    - name: Get input
+      ansible.builtin.pause:
+        prompt: "Enter clone method 'https' or 'git'"
+      register: clone_method
+      until: input.user_input | lower in ['https', 'git']
+      retries: 3
+      delay: 0
+
     - name: Confirm prerequisite environment variables are set
       ansible.builtin.assert:
         that: lookup('env', item.variable) | length > 0
@@ -138,12 +146,13 @@
         dest: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/ansible_collections/cloudera/{{ item.collection}}"
         version: devel
       loop:
-        - repo: git@github.com:cloudera-labs/cloudera.cloud.git
+        - repo: "{{ 'https://github.com/cloudera-labs/cloudera.cloud.git' if clone_method == 'HTTPS' else 'git@github.com:cloudera-labs/cloudera.cloud.git' }}"
           collection: cloud
-        - repo: git@github.com:cloudera-labs/cloudera.cluster.git
+        - repo: "{{ 'https://github.com/cloudera-labs/cloudera.cluster.git' if clone_method == 'HTTPS' else 'git@github.com:cloudera-labs/cloudera.cluster.git' }}"
           collection: cluster
-        - repo: git@github.com:cloudera-labs/cloudera.exe.git
+        - repo: "{{ 'https://github.com/cloudera-labs/cloudera.exe.git' if clone_method == 'HTTPS' else 'git@github.com:cloudera-labs/cloudera.exe.git' }}"
           collection: exe
+      when: clone_method in ['HTTPS', 'GIT']
       register: __cldr_collections
       tags:
         - collections


### PR DESCRIPTION
### Description

This pull request addresses the need to enhance the **local_development.yml** configuration file, providing users with the option to choose their preferred clone method between _HTTPS_ and _GIT_. 

This improvement allows for greater customization and flexibility during the development environment setup process.

### Changes

- Added a new variable _clone_method_ to the _vars_prompt_ section of the playbook.
- The clone_method variable allows users to select either _HTTPS_ or _GIT_ as their preferred clone method.
- Modified the repository cloning task to use the selected clone method specified by the clone_method variable.
- Included a default value of _HTTPS_ for the clone_method variable to ensure seamless execution for users who do not make a selection.

### Testing

Thoroughly tested the playbook with both _HTTPS_ and _GIT_ clone methods to verify functionality and correctness.
Ensured that the default behavior remains consistent and functional.

### Related Issues:

Fixes #49 