### PR TITLE
Add cloud.terraform collection to base image

### DIFF
--- a/local_development.yml
+++ b/local_development.yml
@@ -157,6 +157,8 @@
           collection: cluster
         - repo: git@github.com:cloudera-labs/cloudera.exe.git
           collection: exe
+        - repo: git@github.com:ansible-collections/cloud.terraform.git
+          collection: terraform
       register: __cldr_collections
       tags:
         - collections


### PR DESCRIPTION
### Description

This pull request addresses the need to include the **cloud.terraform** collection in the base image. This addition is essential to ensure that the base image is well-equipped with the necessary tools and resources for seamless **Terraform** deployments and infrastructure management.

### Changes

- Added the cloud.terraform collection to the base image.

### Related Issues

Fixes #51 