### PR TITLE
Update ansible-core to handle point releases

### DIFF
--- a/base/execution-environment.yml
+++ b/base/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 dependencies:
   ansible_core:
-    package_pip: ansible-core~=2.12.0
+    package_pip: ansible-core~=2.12.10
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt

--- a/base/execution-environment.yml
+++ b/base/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.12.*
+    package_pip: ansible-core~=2.12.0
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt


### PR DESCRIPTION
Need `2.12.10` or higher.

Closes #63 