### PR TITLE
Updated image name to allow simple tags

### DIFF
--- a/.github/workflows/build_push_image.yml
+++ b/.github/workflows/build_push_image.yml
@@ -55,16 +55,16 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}-${{ inputs.PROFILE }}
           flavor: |
             latest=auto
-            prefix=${{ inputs.PROFILE }}-,onlatest=true
+            prefix=onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix=${{ inputs.PROFILE }}-
+            type=sha
 
       - name: Construct short SHA
         id: sha
@@ -73,9 +73,9 @@ jobs:
       - name: Update container base image reference
         if: ${{ inputs.PROFILE != 'base' }}
         env:
-          REPLACEMENT_IMAGE: ${{ github.repository }}:base-${{ steps.sha.outputs.sha-short }}
+          REPLACEMENT_IMAGE: ${{ github.repository }}-base:${{ steps.sha.outputs.sha-short }}
         run:
-          sed -i 's|cloudera-labs/cldr-runner:base-latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
+          sed -i 's|cloudera-labs/cldr-runner-base:latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
 
       - name: Create builder context
         run: |

--- a/.github/workflows/build_push_image.yml
+++ b/.github/workflows/build_push_image.yml
@@ -58,7 +58,6 @@ jobs:
             ghcr.io/${{ github.repository }}-${{ inputs.PROFILE }}
           flavor: |
             latest=auto
-            prefix=onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build_push_image.yml
+++ b/.github/workflows/build_push_image.yml
@@ -45,14 +45,14 @@ jobs:
       registry-paths: ${{ steps.push-image.outputs.registry-paths }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install latest ansible-builder
         run: pip install ansible-builder
 
       - name: Construct image metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}-${{ inputs.PROFILE }}

--- a/.github/workflows/build_push_image.yml
+++ b/.github/workflows/build_push_image.yml
@@ -31,7 +31,7 @@ on:
         value: ${{ jobs.build-push.outputs.registry-paths }}
       image-sha:
         description: 'the SHA-tagged image path'
-        value: ghcr.io/${{ github.repository }}:sha-${{ jobs.build-push.outputs.sha-short }}
+        value: ghcr.io/${{ github.repository }}-${{ inputs.PROFILE }}:sha-${{ jobs.build-push.outputs.sha-short }}
 
 permissions:
   contents: read
@@ -72,7 +72,7 @@ jobs:
       - name: Update container base image reference
         if: ${{ inputs.PROFILE != 'base' }}
         env:
-          REPLACEMENT_IMAGE: ${{ github.repository }}-base:${{ steps.sha.outputs.sha-short }}
+          REPLACEMENT_IMAGE: ${{ github.repository }}-base:sha-${{ steps.sha.outputs.sha-short }}
         run:
           sed -i 's|cloudera-labs/cldr-runner-base:latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
 

--- a/.github/workflows/validate_image.yml
+++ b/.github/workflows/validate_image.yml
@@ -71,14 +71,14 @@ jobs:
           ansible-builder create --file ${{ inputs.PROFILE }}/execution-environment.yml
 
       - name: Upload Containerfile
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.PROFILE }}-Containerfile
           path: ./context/Containerfile
       
       - name: Download the base image
         if: ${{ inputs.PROFILE != 'base' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: base-${{ steps.sha.outputs.sha-short }}
           path: /tmp
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload base image
         if: ${{ inputs.PROFILE == 'base' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base-${{ steps.sha.outputs.sha-short }}
           path: /tmp/base-${{ steps.sha.outputs.sha-short }}.tar

--- a/.github/workflows/validate_image.yml
+++ b/.github/workflows/validate_image.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Update container base image reference
         if: ${{ inputs.PROFILE != 'base' }}
         env:
-          REPLACEMENT_IMAGE: ${{ github.repository }}-base:${{ steps.sha.outputs.sha-short }}
+          REPLACEMENT_IMAGE: ${{ github.repository }}-base:sha-${{ steps.sha.outputs.sha-short }}
         run:
           sed -i 's|cloudera-labs/cldr-runner-base:latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
 
@@ -105,9 +105,9 @@ jobs:
       - name: Save the base image
         if: ${{ inputs.PROFILE == 'base' }}
         env:
-          BASE_IMAGE: base-${{ steps.sha.outputs.sha-short }}
+          BASE_IMAGE: ${{ steps.sha.outputs.sha-short }}
         run: |
-          podman save --output /tmp/${{ env.BASE_IMAGE }}.tar ${{ github.repository }}:${{ env.BASE_IMAGE }}
+          podman save --output /tmp/base-${{ env.BASE_IMAGE }}.tar ${{ github.repository }}-base:sha-${{ env.BASE_IMAGE }}
 
       - name: Upload base image
         if: ${{ inputs.PROFILE == 'base' }}

--- a/.github/workflows/validate_image.yml
+++ b/.github/workflows/validate_image.yml
@@ -35,26 +35,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install latest ansible-builder
         run: pip install ansible-builder
     
       - name: Construct image metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}-${{ inputs.PROFILE }}
           flavor: |
             latest=auto
-            prefix=${{ inputs.PROFILE }}-,onlatest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix=${{ inputs.PROFILE }}-
+            type=sha
 
       - name: Construct short SHA
         id: sha
@@ -63,9 +62,9 @@ jobs:
       - name: Update container base image reference
         if: ${{ inputs.PROFILE != 'base' }}
         env:
-          REPLACEMENT_IMAGE: ${{ github.repository }}:base-${{ steps.sha.outputs.sha-short }}
+          REPLACEMENT_IMAGE: ${{ github.repository }}-base:${{ steps.sha.outputs.sha-short }}
         run:
-          sed -i 's|cloudera-labs/cldr-runner:base-latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
+          sed -i 's|cloudera-labs/cldr-runner-base:latest|${{ env.REPLACEMENT_IMAGE }}|' ${{ inputs.PROFILE }}/execution-environment.yml
 
       - name: Create builder context
         run: |

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -53,7 +53,7 @@ jobs:
           echo $PR_NUMBER > ./pr/pr_number
       
       - name: Upload the PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Cloudera, Inc.
+   Copyright 2024 Cloudera, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Specifically, the project consists of `execution-environment.yml` configuration files and other supporting assets that power [`ansible-builder`](https://ansible.readthedocs.io/projects/builder/en/latest/). The configurations encapsulate the necessary Ansible collections and roles, Python libraries, and system applications to work with Cloudera's products and cloud providers. Moreover, the resulting images have the needed tooling for managing infrastructure if so requested.
 
-`cldr-runner` builds several variations:
+`cldr-runner` builds several profiles:
 
 | Tag | Description |
 |-----|-------------|
@@ -15,6 +15,8 @@ Specifically, the project consists of `execution-environment.yml` configuration 
 | [azure](azure/execution-environment.yml) | `base` plus Azure-specific collections and dependencies, including the `az` CLI |
 | [gcp](gcp/execution-environment.yml) | `base` plus GCP-specific collections and dependencies, including the `gcloud` CLI |
 | [full](full/execution-environment.yml) | All of the above, plus additional CLI tools for in-container usage, e.g. `git`, `vim`, `nano`, `tree`, `kubectl` |
+
+Each image is tagged `cloudera-labs/cldr-runner-<profile>:<version>`.
 
 # Quickstart
 
@@ -52,7 +54,7 @@ ansible-navigator:
   execution-environment:
     container-engine: docker
     enabled: True
-    image: ghcr.io/cloudera-labs/cldr-runner:aws-latest
+    image: ghcr.io/cloudera-labs/cldr-runner-aws:latest
     pull:
       policy: missing
 ```
@@ -78,7 +80,7 @@ Once defined, the EE can be used by Job Templates, Container Groups, etc.
 You can run the container directly in `docker` (or `podman`):
 
 ```bash
-docker run -it ghcr.io/cloudera-labs/cldr-runner:aws-latest /bin/bash
+docker run -it ghcr.io/cloudera-labs/cldr-runner-aws:latest /bin/bash
 ```
 
 Take care to assemble and mount the needed directories other supporting assets; the image is based on [`ansible-runner`](https://ansible.readthedocs.io/projects/runner/en/stable/) (as are all Execution Environments) and runs as such.
@@ -121,7 +123,7 @@ version: 3
 
 images:
   base_image:
-    name: ghcr.io/cloudera-labs/cldr-runner:aws-latest
+    name: ghcr.io/cloudera-labs/cldr-runner-aws:latest
 
 dependencies:
   galaxy:
@@ -209,7 +211,7 @@ Follow these steps to set up a local environment:
 
 # License and Copyright
 
-Copyright 2023, Cloudera, Inc.
+Copyright 2024, Cloudera, Inc.
 
 ```
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/aws/execution-environment.yml
+++ b/aws/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 images:
   base_image:
-    name: ghcr.io/cloudera-labs/cldr-runner:base-latest
+    name: ghcr.io/cloudera-labs/cldr-runner-base:latest
 
 dependencies:
   galaxy: requirements.yml
@@ -31,13 +31,13 @@ additional_build_steps:
   # See https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html
   # See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#cliv2-linux-install
   prepend_final:
-    - ARG BUILD_VER="aws-latest"
+    - ARG BUILD_VER="latest"
     - ARG BUILD_DATE="unknown"
     - ARG BUILD_REVISION="unknown"
     - ENV BUILD_VER="${BUILD_VER}"
     - ENV BUILD_DATE="${BUILD_DATE}"
     - ENV BUILD_REVISION="${BUILD_REVISION}"
-    - LABEL org.opencontainers.image.title="cldr-runner aws"
+    - LABEL org.opencontainers.image.title="cldr-runner-aws"
       org.opencontainers.image.description="Ansible Execution Environment with collections and dependencies for CDP Public Cloud, Private Cloud, and Data Services for AWS."
       org.opencontainers.image.created="${BUILD_DATE}"
       org.opencontainers.image.version="${BUILD_VER}"

--- a/azure/execution-environment.yml
+++ b/azure/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 images:
   base_image:
-    name: ghcr.io/cloudera-labs/cldr-runner:base-latest
+    name: ghcr.io/cloudera-labs/cldr-runner-base:latest
 
 dependencies:
   galaxy: requirements.yml
@@ -29,13 +29,13 @@ dependencies:
       
 additional_build_steps:
   prepend_final:
-    - ARG BUILD_VER="azure-latest"
+    - ARG BUILD_VER="latest"
     - ARG BUILD_DATE="unknown"
     - ARG BUILD_REVISION="unknown"
     - ENV BUILD_VER="${BUILD_VER}"
     - ENV BUILD_DATE="${BUILD_DATE}"
     - ENV BUILD_REVISION="${BUILD_REVISION}"
-    - LABEL org.opencontainers.image.title="cldr-runner azure"
+    - LABEL org.opencontainers.image.title="cldr-runner-azure"
       org.opencontainers.image.description="Ansible Execution Environment with collections and dependencies for CDP Public Cloud, Private Cloud, and Data Services for Azure."
       org.opencontainers.image.created="${BUILD_DATE}"
       org.opencontainers.image.version="${BUILD_VER}"

--- a/base/execution-environment.yml
+++ b/base/execution-environment.yml
@@ -33,7 +33,7 @@ additional_build_steps:
   prepend_builder:
     - RUN yum install -y yum-utils && yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo  
   prepend_final:
-    - ARG BUILD_VER="base-latest"
+    - ARG BUILD_VER="latest"
     - ARG BUILD_DATE="unknown"
     - ARG BUILD_REVISION="unknown"
     - ENV BUILD_VER="${BUILD_VER}"
@@ -45,7 +45,7 @@ additional_build_steps:
       org.opencontainers.image.url="https://github.com/cloudera-labs/cldr-runner/blob/main/README.md"
       org.opencontainers.image.source="https://github.com/cloudera-labs/cldr-runner.git"
       org.opencontainers.image.licenses=Apache-2.0
-      org.opencontainers.image.title="cldr-runner base"
+      org.opencontainers.image.title="cldr-runner-base"
       org.opencontainers.image.description="Ansible Execution Environment with collections and dependencies for CDP Public Cloud, Private Cloud, and Data Services."
       org.opencontainers.image.created="${BUILD_DATE}"
       org.opencontainers.image.version="${BUILD_VER}"

--- a/full/execution-environment.yml
+++ b/full/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 images:
   base_image:
-    name: ghcr.io/cloudera-labs/cldr-runner:base-latest
+    name: ghcr.io/cloudera-labs/cldr-runner-base:latest
 
 dependencies:
   galaxy: requirements.yml
@@ -36,13 +36,13 @@ additional_build_steps:
     - ADD _build/assets/google-cloud-cli.repo /etc/yum.repos.d/google-cloud-cli.repo
     - RUN yum install -y yum-utils && yum-config-manager --enable google-cloud-cli
   prepend_final:
-    - ARG BUILD_VER="full-latest"
+    - ARG BUILD_VER="latest"
     - ARG BUILD_DATE="unknown"
     - ARG BUILD_REVISION="unknown"
     - ENV BUILD_VER="${BUILD_VER}"
     - ENV BUILD_DATE="${BUILD_DATE}"
     - ENV BUILD_REVISION="${BUILD_REVISION}"
-    - LABEL org.opencontainers.image.title="cldr-runner full"
+    - LABEL org.opencontainers.image.title="cldr-runner-full"
       org.opencontainers.image.description="Ansible Execution Environment with collections and dependencies for CDP Public Cloud, Private Cloud, and Data Services for AWS, Azure, GCP, and other tooling for general development and usage."
       org.opencontainers.image.created="${BUILD_DATE}"
       org.opencontainers.image.version="${BUILD_VER}"

--- a/gcp/execution-environment.yml
+++ b/gcp/execution-environment.yml
@@ -20,7 +20,7 @@ version: 3
 
 images:
   base_image:
-    name: ghcr.io/cloudera-labs/cldr-runner:base-latest
+    name: ghcr.io/cloudera-labs/cldr-runner-base:latest
 
 dependencies:
   galaxy: requirements.yml
@@ -36,13 +36,13 @@ additional_build_steps:
     - ADD _build/assets/google-cloud-cli.repo /etc/yum.repos.d/google-cloud-cli.repo
     - RUN yum install -y yum-utils && yum-config-manager --enable google-cloud-cli
   prepend_final:
-    - ARG BUILD_VER="gcp-latest"
+    - ARG BUILD_VER="latest"
     - ARG BUILD_DATE="unknown"
     - ARG BUILD_REVISION="unknown"
     - ENV BUILD_VER="${BUILD_VER}"
     - ENV BUILD_DATE="${BUILD_DATE}"
     - ENV BUILD_REVISION="${BUILD_REVISION}"
-    - LABEL org.opencontainers.image.title="cldr-runner gcp"
+    - LABEL org.opencontainers.image.title="cldr-runner-gcp"
       org.opencontainers.image.description="Ansible Execution Environment with collections and dependencies for CDP Public Cloud, Private Cloud, and Data Services for GCP."
       org.opencontainers.image.created="${BUILD_DATE}"
       org.opencontainers.image.version="${BUILD_VER}"


### PR DESCRIPTION
Using "compound" tags, like `aws-latest`, breaks the `latest` pull policy for `ansible-navigator`.